### PR TITLE
MonoDevelop relocate mono script fix and updated monodevelop.patch

### DIFF
--- a/patches/monodevelop.patch
+++ b/patches/monodevelop.patch
@@ -31,9 +31,18 @@ index 7697bc9..3bc1dc0 100644
  			defaultHandler = "MonoDevelop.Ide.Commands.TipOfTheDayHandler"
  			_label = "_Tip of the Day"
 diff --git a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
-index 25cda3e..c35330b 100644
+index 25cda3e..2761f8a 100644
 --- a/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
 +++ b/main/src/core/MonoDevelop.Ide/ExtensionModel/MainMenu.addin.xml
+@@ -241,7 +241,7 @@
+ 	</ItemSet> 
+ 
+ 	<ItemSet id = "Help" _label = "_Help">
+-		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.Help" />
++<!--		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.Help" /> -->
+ 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.TipOfTheDay" />
+ 		<CommandItem id = "MonoDevelop.Ide.Commands.HelpCommands.SendFeedback" />
+ 		<Condition id = "Platform" value = "!mac">
 @@ -260,7 +260,7 @@
  		</ItemSet>
  		<SeparatorItem id = "Separator3" />
@@ -153,7 +162,7 @@ index 7966655..85c2410 100644
  			parent.Add (mainAlignment);
  		}
 diff --git a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
-index 7f2e8c2..940450a 100644
+index 7f2e8c2..dfb4926 100644
 --- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
 +++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/IdeStartup.cs
 @@ -60,7 +60,7 @@ namespace MonoDevelop.Ide
@@ -200,6 +209,33 @@ index 7f2e8c2..940450a 100644
  				}
  			}
  			
+@@ -654,6 +663,26 @@ namespace MonoDevelop.Ide
+ 						"may not be properly installed in the GAC.",
+ 						BrandingService.ApplicationName
+ 					), ex);
++
++				if (Platform.IsWindows)
++				{
++					string url = "http://monodevelop.com/Download";
++					string caption = "Fatal Error";
++					string message =
++						"{0} failed to start. Some of the assemblies required to run {0} (for example GTK#) " +
++						"may not be properly installed in the GAC.\n\r\n\r" +
++						"Please click OK to open the download page, where " +
++						"you can download the necessary dependencies for {0} to run.";
++
++					if (DisplayWindowsOkCancelMessage(
++						string.Format(message, BrandingService.ApplicationName, url), caption)
++					)
++					{
++						Process.Start(url);
++					}
++				}
++
++
+ 			} finally {
+ 				Runtime.Shutdown ();
+ 			}
 diff --git a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
 index 38c6ddb..45d7416 100644
 --- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs


### PR DESCRIPTION
- Updated monodevelop.patch according to this PR: https://github.com/Unity-Technologies/monodevelop/pull/70. 
  Fixes case 735412 "When GTK is uninstalled there is no messages that explain why MD doesn't start. And"
- OSX: Updated the generated MonoDevelop relocate mono script to not patch the Mono framework files inside the MonoDevelop.app bundle. 
  Instead, the Mono framework paths are patched to `/tmp/unity-monodevelop-monoframework-<VERSION>` in update_mono_framework.pl and only the symlink from `/tmp/unity-monodevelop-monoframework-<VERSION>` to the bundled Mono is created when starting MonoDevelop.
  Fixes case 739514 "MonoDevelop won't start on OS X when logged as not admin user". Won't start because non-admin users do not have write permissions in /Applications.

The cases above have been verified as fixed by QA using a build from the unity-staging branch.
