### PR TITLE
Update build scripts and patches

### DIFF
--- a/apply_monodevelop_patches.pl
+++ b/apply_monodevelop_patches.pl
@@ -16,8 +16,13 @@ sub apply_mono_develop_patches()
 	system("git apply --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/monodevelop.patch") && die("Failed to apply monodevelop.patch");
 
 	print "Applying debugger-libs.patch\n";
-	chdir "main/external/debugger-libs";
+	chdir "$root/monodevelop/main/external/debugger-libs";
 	system("git apply --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/debugger-libs.patch") && die("Failed to apply debugger-libs.patch");
+
+	print "Applying mono-addins.patch\n";
+	chdir "$root/monodevelop/main/external/mono-addins";
+	system("git apply --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/mono-addins.patch") && die("Failed to apply mono-addins.patch");
+
 }
 
 sub reverse_mono_develop_patches()
@@ -30,9 +35,12 @@ sub reverse_mono_develop_patches()
 	system("git apply --reverse --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/monodevelop.patch") && die("Failed to reverse monodevelop.patch");
 
 	print "Reversing debugger-libs.patch\n";
-	chdir "main/external/debugger-libs";
+	chdir "$root/monodevelop/main/external/debugger-libs";
 	system("git apply --reverse --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/debugger-libs.patch") && die("Failed to reverse debugger-libs.patch");
 
+	print "Reversing mono-addins.patch\n";
+	chdir "$root/monodevelop/main/external/mono-addins";
+	system("git apply --reverse --ignore-space-change --ignore-whitespace $buildRepoRoot/patches/mono-addins.patch") && die("Failed to reverse mono-addins.patch");
 }
 
 1;

--- a/build_mac.pl
+++ b/build_mac.pl
@@ -55,9 +55,9 @@ sub main {
 sub prepare_sources {
 	chdir $root;
 	die ("Must grab MonoDevelop checkout from github first") if !-d "monodevelop";
+	die ("Must grab Unity MonoDevelop Soft Debugger source from github first") if !-d "MonoDevelop.Debugger.Soft.Unity";
 	if (!$unityMode)
 	{
-		die ("Must grab Unity MonoDevelop Soft Debugger source from github first") if !-d "MonoDevelop.Debugger.Soft.Unity";
 		die ("Must grab Unity Add-ins for Boo and Unity source from github first") if !-d "MonoDevelop.Boo.UnityScript.Addins";
 		die ("Must grab Boo implementation") if !-d "boo";
 		die ("Must grab Boo extensions") if !-d "boo-extensions";

--- a/build_mac.pl
+++ b/build_mac.pl
@@ -147,7 +147,8 @@ sub build_monodevelop {
 
 	system("make clean all") && die("Failed building MonoDevelop");
 	mkpath("main/build/bin/branding");
-	copy("$buildRepoRoot/dependencies/Branding.xml", "main/build/bin/branding/Branding.xml") or die("failed copying branding");
+	copy("$buildRepoRoot/dependencies/Branding.xml", "main/build/bin/branding/Branding.xml") or die("failed copying Branding.xml");
+	copy("$buildRepoRoot/dependencies/addins-config.xml", "main/build/bin/addins-config.xml") or die("failed copying addins-config.xml");
 }
 
 sub build_debugger_addin {

--- a/build_mac.pl
+++ b/build_mac.pl
@@ -46,6 +46,7 @@ sub main {
 		build_unityscript();
 		build_boo_unity_addins();
 	} else {
+		build_debugger_addin();
 		build_unitymode_addin();
 	}
 	package_monodevelop();

--- a/build_windows.pl
+++ b/build_windows.pl
@@ -220,7 +220,8 @@ sub package_monodevelop
 	mkpath("$mdRoot/bin/branding");
 	mkpath "$mdRoot/GTKSharp";
 	
-	copy("$buildRepoRoot/dependencies/Branding.xml", "$mdRoot/bin/branding/Branding.xml") or die("failed copying branding");
+	copy("$buildRepoRoot/dependencies/Branding.xml", "$mdRoot/bin/branding/Branding.xml") or die("failed copying Branding.xml");
+	copy("$buildRepoRoot/dependencies/addins-config.xml", "$mdRoot/bin/addins-config.xml") or die("failed copying addins-config.xml");
 	copy("$buildRepoRoot/dependencies/$GTK_INSTALLER", "$mdRoot/GTKSharp/gtk-sharp.msi") or die ("failed copying $GTK_INSTALLER");
 
 	system("xcopy /s \"$mdSource/bin\" \"$mdRoot/bin\"");

--- a/build_windows.pl
+++ b/build_windows.pl
@@ -6,6 +6,7 @@ use File::Spec;
 use File::Copy;
 use File::Path;
 use Digest::MD5;
+use Getopt::Long;
 
 require "remove_unwanted_addins.pl";
 require "apply_monodevelop_patches.pl";
@@ -28,6 +29,9 @@ my $mdSource = "$root/monodevelop/main/build";
 
 my $nant = "\"$buildRepoRoot/dependencies/nant-0.93-nightly-2015-02-12/bin/NAnt.exe\"";
 my $incremental = "/t:Rebuild";
+my $unityMode = 0;
+
+GetOptions ("unitymode=i" => \$unityMode);
 
 main();
 
@@ -44,12 +48,18 @@ sub main {
 	reverse_mono_develop_patches($root, $buildRepoRoot);
 	remove_unwanted_addins();
 
-	# Build Unity Add-ins
-	build_debugger_addin();
-	build_boo();
-	build_boo_extensions();
-	build_unityscript();
-	build_boo_unity_addins();
+	if (!$unityMode)
+	{
+		# Build Unity Add-ins
+		build_debugger_addin();
+		build_boo();
+		build_boo_extensions();
+		build_unityscript();
+		build_boo_unity_addins();
+	} else {
+		build_debugger_addin();
+		build_unitymode_addin();
+	}
 
 	package_monodevelop();
 }
@@ -182,6 +192,15 @@ sub build_boo_unity_addins()
 
 	system("\"$ENV{VS100COMNTOOLS}/vsvars32.bat\" && msbuild $root\\MonoDevelop.Boo.UnityScript.Addins\\MonoDevelop.Boo.UnityScript.Addins.sln /p:OutputPath=\"$addinsdir\\MonoDevelop.Boo.UnityScript.Addins\" /p:Configuration=Release $incremental") && die ("Failed to compile MonoDevelop UnityScript/Boo add-ins");
 }
+
+sub build_unitymode_addin ()
+{
+	my $addinsdir = "$root\\monodevelop\\main\\build\\Addins";
+	mkpath "$addinsdir\\MonoDevelop.UnityMode";
+
+	system("\"$ENV{VS100COMNTOOLS}/vsvars32.bat\" && msbuild $root\\MonoDevelop.UnityMode\\MonoDevelop.UnityMode.sln /p:OutputPath=\"$addinsdir\\MonoDevelop.UnityMode\" /p:Configuration=Release $incremental") && die ("Failed to compile MonoDevelop UnityMode add-in");
+}
+
 
 sub package_monodevelop 
 {

--- a/build_windows.pl
+++ b/build_windows.pl
@@ -68,10 +68,16 @@ sub prepare_sources {
 	chdir $root;
 	die ("Must grab MonoDevelop checkout from github first") if !-d "monodevelop";
 	die ("Must grab Unity MonoDevelop Soft Debugger source from github first") if !-d "MonoDevelop.Debugger.Soft.Unity";
-	die ("Must grab Unity Add-ins for Boo and Unity source from github first") if !-d "MonoDevelop.Boo.UnityScript.Addins";
-	die ("Must grab Boo implementation") if !-d "boo";
-	die ("Must grab Boo extensions") if !-d "boo-extensions";
-	die ("Must grab Unityscript implementation") if !-d "unityscript";
+	
+	if (!$unityMode)
+	{
+		die ("Must grab Unity Add-ins for Boo and Unity source from github first") if !-d "MonoDevelop.Boo.UnityScript.Addins";
+		die ("Must grab Boo implementation") if !-d "boo";
+		die ("Must grab Boo extensions") if !-d "boo-extensions";
+		die ("Must grab Unityscript implementation") if !-d "unityscript";
+	} else {
+		die ("Must grab MonoDevelop.UnityMode source from github first") if !-d "MonoDevelop.UnityMode";
+	}
 }
 
 sub setup_env {

--- a/dependencies/addins-config.xml
+++ b/dependencies/addins-config.xml
@@ -1,0 +1,8 @@
+<Configuration>
+  <AddinStatus>
+    <Addin id="MonoDevelop.NUnit" enabled="False" />
+    <Addin id="MonoDevelop.VersionControl.Subversion.Windows" enabled="False" />
+    <Addin id="MonoDevelop.VersionControl.Subversion.Unix" enabled="False" />
+    <Addin id="MonoDevelop.VersionControl.Git" enabled="False" />
+  </AddinStatus>
+</Configuration>

--- a/dependencies/template.app/Contents/Info.plist
+++ b/dependencies/template.app/Contents/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>MonoDevelop</string>
+	<string>monodevelop</string>
 	<key>CFBundleIconFile</key>
 	<string>monodevelop.icns</string>
 	<key>LSApplicationCategoryType</key>

--- a/patches/mono-addins.patch
+++ b/patches/mono-addins.patch
@@ -1,0 +1,63 @@
+diff --git a/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs b/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
+index 5f3a6ff..d918747 100644
+--- a/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
++++ b/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
+@@ -1806,7 +1806,7 @@ namespace Mono.Addins.Database
+ 						if (fileDatabase.Exists (ConfigFile))
+ 							config = DatabaseConfiguration.Read (ConfigFile);
+ 						else
+-							config = new DatabaseConfiguration ();
++							config = DatabaseConfiguration.ReadAppConfig ();
+ 					}
+ 				}
+ 				return config;
+diff --git a/Mono.Addins/Mono.Addins.Database/DatabaseConfiguration.cs b/Mono.Addins/Mono.Addins.Database/DatabaseConfiguration.cs
+index 77270bf..3144b40 100644
+--- a/Mono.Addins/Mono.Addins.Database/DatabaseConfiguration.cs
++++ b/Mono.Addins/Mono.Addins.Database/DatabaseConfiguration.cs
+@@ -76,10 +76,6 @@ namespace Mono.Addins.Database
+ 			AddinStatus s;
+ 			addinStatus.TryGetValue (addinName, out s);
+ 			
+-			if (enabled == defaultValue) {
+-				addinStatus.Remove (addinName);
+-				return;
+-			}
+ 			if (s == null)
+ 				s = addinStatus [addinName] = new AddinStatus (addinName);
+ 			s.Enabled = enabled;
+@@ -121,6 +117,34 @@ namespace Mono.Addins.Database
+ 		
+ 		public static DatabaseConfiguration Read (string file)
+ 		{
++			var config = ReadInternal (file);
++			// Try to read application level config to support disabling add-ins by default.
++			var appConfig = ReadAppConfig ();
++
++			if (appConfig == null)
++				return config;
++
++			// Overwrite app config values with user config values
++			foreach (var entry in config.addinStatus)
++				appConfig.addinStatus [entry.Key] = entry.Value;
++
++			return appConfig;
++		}
++		
++		public static DatabaseConfiguration ReadAppConfig()
++		{
++			var assemblyPath = System.Reflection.Assembly.GetExecutingAssembly ().Location;
++			var assemblyDirectory = Path.GetDirectoryName (assemblyPath);
++			var appAddinsConfigFilePath = Path.Combine (assemblyDirectory, "addins-config.xml");
++
++			if (!File.Exists (appAddinsConfigFilePath))
++				return new DatabaseConfiguration ();
++
++			return ReadInternal (appAddinsConfigFilePath);
++		}
++
++		static DatabaseConfiguration ReadInternal (string file)
++		{
+ 			DatabaseConfiguration config = new DatabaseConfiguration ();
+ 			XmlDocument doc = new XmlDocument ();
+ 			doc.Load (file);

--- a/patches/monodevelop.patch
+++ b/patches/monodevelop.patch
@@ -10,6 +10,18 @@ index 1b7865d..719059c 100644
  
  			state = new TreeViewState (tree, 1);
  
+diff --git a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+index 7855e35..db2dccb 100644
+--- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
++++ b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
+@@ -712,6 +712,7 @@ namespace MonoDevelop.SourceEditor
+ 						}
+ 					}
+ 					Mono.TextEditor.Utils.TextFileUtility.WriteText (fileName, writeText, writeEncoding, writeBom);
++					this.encoding = writeEncoding;
+ 				} catch (InvalidEncodingException) {
+ 					var result = MessageService.AskQuestion (GettextCatalog.GetString ("Can't save file with current codepage."), 
+ 						GettextCatalog.GetString ("Some unicode characters in this file could not be saved with the current encoding.\nDo you want to resave this file as Unicode ?\nYou can choose another encoding in the 'save as' dialog."),
 diff --git a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml b/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml
 index 7697bc9..3bc1dc0 100644
 --- a/main/src/core/MonoDevelop.Ide/ExtensionModel/Commands.addin.xml

--- a/patches/monodevelop.patch
+++ b/patches/monodevelop.patch
@@ -236,6 +236,37 @@ index 7f2e8c2..dfb4926 100644
  			} finally {
  				Runtime.Shutdown ();
  			}
+diff --git a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+index 6061295..5f07cb2 100644
+--- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
++++ b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/ProjectOperations.cs
+@@ -109,7 +109,7 @@ namespace MonoDevelop.Ide
+ 			get {
+ 				return currentWorkspaceItem;
+ 			}
+-			internal set {
++			set {
+ 				if (value != currentWorkspaceItem) {
+ 					WorkspaceItem oldValue = currentWorkspaceItem;
+ 					currentWorkspaceItem = value;
+@@ -125,7 +125,7 @@ namespace MonoDevelop.Ide
+ 					return CurrentSelectedSolution.RootFolder;
+ 				return currentSolutionItem;
+ 			}
+-			internal set {
++			set {
+ 				if (value != currentSolutionItem) {
+ 					SolutionItem oldValue = currentSolutionItem;
+ 					currentSolutionItem = value;
+@@ -139,7 +139,7 @@ namespace MonoDevelop.Ide
+ 			get {
+ 				return currentItem;
+ 			}
+-			internal set {
++			set {
+ 				currentItem = value;
+ 			}
+ 		}
 diff --git a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs b/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs
 index 38c6ddb..45d7416 100644
 --- a/main/src/core/MonoDevelop.Ide/MonoDevelop.Ide/RootWorkspace.cs

--- a/remove_unwanted_addins.pl
+++ b/remove_unwanted_addins.pl
@@ -65,6 +65,7 @@ sub IsBlackListed {
 
 	# Blacklist local build of the add-ins.
 	return 1 if $path =~ /MonoDevelop.Boo.UnityScript.Addins/;
+	return 1 if $path =~ /MonoDevelop.UnityMode/;
 
 	return 0;
 }

--- a/updatepatches.sh
+++ b/updatepatches.sh
@@ -21,3 +21,12 @@ git checkout unity-trunk
 git pull origin unity-trunk
 
 git diff unity-trunk...unity-trunk-patch > ${CURRENT}/patches/debugger-libs.patch
+
+cd ${ROOT}/mono-addins
+
+git checkout unity-trunk-patch
+git pull origin unity-trunk-patch
+git checkout unity-trunk
+git pull origin unity-trunk
+
+git diff unity-trunk...unity-trunk-patch > ${CURRENT}/patches/mono-addins.patch


### PR DESCRIPTION
- Update build scripts to build MonoDevelop with UnityMode  (Rest Integration) correctly on OSX and Windows.
- Update patches from reviewed PRs:
  - Unity-Technologies/monodevelop#71
  - Unity-Technologies/monodevelop#72
  - Unity-Technologies/mono-addins#1
- Added addins-config.xml to disable some shipped add-ins that have been causing issues for the users.
