### PR TITLE
OSX case-sensitive filesystem fix and updated patches

### DIFF
--- a/build_mac.pl
+++ b/build_mac.pl
@@ -152,7 +152,7 @@ sub build_monodevelop {
 }
 
 sub build_debugger_addin {
-	my $addinsdir = "$root/monodevelop/main/build/Addns/";
+	my $addinsdir = "$root/monodevelop/main/build/AddIns/";
 	chdir "$root/MonoDevelop.Debugger.Soft.Unity";
 	mkpath "$addinsdir/MonoDevelop.Debugger.Soft.Unity";
 	system("xbuild /property:Configuration=Release /t:Rebuild /p:OutputPath=\"$addinsdir/MonoDevelop.Debugger.Soft.Unity\"") && die("Failed building Unity debugger addin");

--- a/build_mac.pl
+++ b/build_mac.pl
@@ -152,7 +152,7 @@ sub build_monodevelop {
 }
 
 sub build_debugger_addin {
-	my $addinsdir = "$root/monodevelop/main/build/Addins/";
+	my $addinsdir = "$root/monodevelop/main/build/Addns/";
 	chdir "$root/MonoDevelop.Debugger.Soft.Unity";
 	mkpath "$addinsdir/MonoDevelop.Debugger.Soft.Unity";
 	system("xbuild /property:Configuration=Release /t:Rebuild /p:OutputPath=\"$addinsdir/MonoDevelop.Debugger.Soft.Unity\"") && die("Failed building Unity debugger addin");
@@ -181,14 +181,14 @@ sub build_unityscript {
 }
 
 sub build_boo_unity_addins {
-	my $addinsdir = "$root/monodevelop/main/build/Addins/";
+	my $addinsdir = "$root/monodevelop/main/build/AddIns/";
 	chdir "$root/MonoDevelop.Boo.UnityScript.Addins";
 	mkpath "$addinsdir/MonoDevelop.Boo.UnityScript.Addins";
 	system("xbuild /property:Configuration=Release /t:Rebuild /p:OutputPath=\"$addinsdir/MonoDevelop.Boo.UnityScript.Addins\"") && die("Failed building Unity debugger addin");
 }
 
 sub build_unitymode_addin {
-	my $addinsdir = "$root/monodevelop/main/build/Addins/";
+	my $addinsdir = "$root/monodevelop/main/build/AddIns/";
 	chdir "$root/MonoDevelop.UnityMode";
 	mkpath "$addinsdir/MonoDevelop.UnityMode";
 	system("xbuild /property:Configuration=Release /t:Rebuild /p:OutputPath=\"$addinsdir/MonoDevelop.UnityMode\"") && die("Failed building MonoDevelop.UnityMode");
@@ -210,7 +210,7 @@ sub package_monodevelop {
 	system("cp -R $buildRepoRoot/dependencies/Mono.framework \"$targetapp/Contents/Frameworks/\"");
 	
 	mkpath($monodeveloptarget);
-	system("cp -r $monodevelopbuild/Addins \"$monodeveloptarget/\"");
+	system("cp -r $monodevelopbuild/AddIns \"$monodeveloptarget/\"");
 	system("cp -r $monodevelopbuild/bin \"$monodeveloptarget/\"");
 	system("cp -r $monodevelopbuild/data \"$monodeveloptarget/\"");
 

--- a/patches/monodevelop.patch
+++ b/patches/monodevelop.patch
@@ -10,6 +10,31 @@ index 1b7865d..719059c 100644
  
  			state = new TreeViewState (tree, 1);
  
+diff --git a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+index 8e11088..83dbccb 100644
+--- a/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
++++ b/main/src/addins/MonoDevelop.Debugger/MonoDevelop.Debugger/BreakpointPropertiesDialog.cs
+@@ -188,6 +188,12 @@ namespace MonoDevelop.Debugger
+ 			Sensitive = false,
+ 			TextAlignment = Alignment.End
+ 		};
++
++		readonly Label exceptionTypeTip = new Label (GettextCatalog.GetString ("Exception list is generated from currently selected project.")) {
++			Sensitive = false,
++			TextAlignment = Alignment.End
++		};
++
+ 		readonly Label conditionalExpressionTip = new Label (GettextCatalog.GetString ("A C# boolean expression. Scope is local to the breakpoint.")) {
+ 			Sensitive = false,
+ 			TextAlignment = Alignment.End
+@@ -764,6 +770,7 @@ namespace MonoDevelop.Debugger
+ 				hboxException.PackEnd (warningException);
+ 
+ 				vboxException.PackStart (hboxException);
++				vboxException.PackStart (exceptionTypeTip);
+ 				vboxException.PackStart (checkIncludeSubclass);
+ 				whenToTakeActionRadioGroup.PackStart (vboxException);
+ 			}
 diff --git a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs b/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs
 index 7855e35..db2dccb 100644
 --- a/main/src/addins/MonoDevelop.SourceEditor2/MonoDevelop.SourceEditor/SourceEditorView.cs


### PR DESCRIPTION
- build_mac.pl Renamed MonoDevelop add-ins folder from "Addins" to "AddIns" (capital I) to fix issues with running MD on case sensitive file systems.
- Updated monodevelop.patch
  - GitHub PR: Unity-Technologies/monodevelop#73
