### PR TITLE
Do not disable NUnit add-in per default

### DIFF
--- a/dependencies/addins-config.xml
+++ b/dependencies/addins-config.xml
@@ -1,6 +1,5 @@
 <Configuration>
   <AddinStatus>
-    <Addin id="MonoDevelop.NUnit" enabled="False" />
     <Addin id="MonoDevelop.VersionControl.Subversion.Windows" enabled="False" />
     <Addin id="MonoDevelop.VersionControl.Subversion.Unix" enabled="False" />
     <Addin id="MonoDevelop.VersionControl.Git" enabled="False" />


### PR DESCRIPTION
Required by CSharpBinding add-in. Fixes issue with error dialog on startup.
